### PR TITLE
Reveal the Medallion of the Scrolls: Banner Moved to the Asset Temple

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # 🐧 The GitScrolls 📜
 
+![Tux the penguin sits among classical Greek philosophers in togas, typing on a laptop while ancient thinkers gesture and debate around marble columns, representing the blend of timeless wisdom and modern software development](https://github.com/gitscrolls/gitscrolls-assets/blob/main/tuxicles.png?raw=true)
+
 _Sacred wisdom for the journey from first commit to final teaching_
 
 


### PR DESCRIPTION
A lone image now stands above the title—a scene of Tuxicles among philosophers, summoned not from local weight, but from the sacred vault of gitscrolls-assets.

This banner sets the tone: not merely documentation, but myth. Not a README, but a scroll.

Let the image speak as the philosophers did—silently, and with infinite debate.