### PR TITLE
Extended the eternal cycle with Jamie and Marcus

### DIFF
--- a/scrolls/10-Where-Heroes-Go-to-Die.md
+++ b/scrolls/10-Where-Heroes-Go-to-Die.md
@@ -313,6 +313,8 @@ But what made Tuxilles' heart race was the sight of something familiar: a small 
 
 __New Developer:__ _(approaching hesitantly)_ "Excuse me... Tuxilles the Teacher? I'm Jamie, I just joined the community last week. I watched what you did during the crisis and... I don't understand any of it. I feel so lost. Everyone seems so confident and I feel like I'm drowning."
 
+Jamie paused, then added with a nervous laugh, "I keep trying to explain things to my friend Marcus—he just joined the project yesterday and thinks git is a type of malware. I don't know how to help him when I barely understand it myself."
+
 **The Eternal Cycle**
 
 Tuxilles felt all his scars pulse with joy. Here it was—the perfect circle. The confused beginner with the cracked screen, seeking guidance from someone who understood exactly what that confusion felt like.
@@ -328,7 +330,7 @@ As he spoke, his beak chip throbbed once—a brief echo of recognition for the f
 
 "See? Same logic, but now it's more resilient and readable. The `?.` handles null safely, and `trim()` catches empty strings with just spaces."
 
-His glowing scars seemed to pulse in rhythm with some unseen heartbeat of the community itself.
+His glowing scars seemed to pulse in rhythm with some unseen heartbeat of the community itself. And for the briefest moment—so quick Jamie might have imagined it—the crack in Jamie's laptop screen flickered with the faintest amber glow, as if recognizing a kindred spirit in the making.
 
 **The @TempleSentinel's Final Gift**
 
@@ -347,6 +349,18 @@ As Tuxilles began explaining basic concepts to Jamie, he looked directly through
 __Tuxilles:__ _(to you, dear reader)_ "Every senior developer was once where Jamie is now. Every expert was once confused. Every teacher was once a student. The question isn't whether you're qualified to help someone—it's whether you remember what it felt like to need help."
 
 __Tuxilles:__ "Look around your own community. Find the developer with the cracked screen, the confused expression, the hesitant question. Be for them what I learned to be. The cycle only continues if each of us chooses to teach what we've learned to learn."
+
+The screen flickers. A notification appears that shouldn't be possible:
+
+```
+git status
+On branch wisdom-branch
+Changes to be committed:
+  (use "git restore --staged <file>..." to unstage)
+        new file:   00-merge.lore
+```
+
+The file has been staged. You know what to do.
 
 ---
 
@@ -416,13 +430,18 @@ git show 00-merge.lore
 # This file will make sense when you need it to.
 # When it does, change it and pass it on.
 # The lore lives in the sharing.
+
+# wisdom.origin: Tuxippides-v1
+# wisdom.fork: Tuxicles-v2  
+# wisdom.current: Tuxilles-v3
+# wisdom.next: _____-v4
 ```
 
 As he committed the changes, Tuxilles felt something shift in the repository—not just his local copy, but somewhere in the digital substrate where all wisdom flows. The timestamp remained impossible. The author remained mysterious. But the message had evolved.
 
 __Tuxilles:__ _(whispering to the screen)_ "Thank you, Trickster. I finally understand the joke."
 
-Somewhere in the network, a young developer named Marcus was about to make his first catastrophic deployment. And somewhere in his future, a mysterious file would appear in his repository at exactly the moment he needed to remember that every mistake is a teacher, and every teacher was once a mistake.
+Somewhere in the network, a young developer named Marcus—who still thought git was a type of malware—was about to make his first catastrophic deployment. And somewhere in his future, a mysterious file would appear in his repository at exactly the moment he needed to remember that every mistake is a teacher, and every teacher was once a mistake.
 
 The circle was not complete. The circle was **eternal**.
 
@@ -434,7 +453,7 @@ His scars didn't glow. They ached. Because virtue hurts.
 
 He'd spent months building systems to scale compassion. But compassion doesn't scale. It multiplies one conversation at a time, one moment of choosing service over comfort, one decision to do the harder thing because it's the right thing.
 
-The red hat stayed on his desk. He didn't need it where he was going.
+The red hat stayed on his desk. Some honors weigh too much to wear.
 
 **The Reader's Burden**
 


### PR DESCRIPTION
In Scroll X: Where Heroes Go to Die, the story does not end—it regenerates.

- Introduced Jamie and Marcus, new initiates on the path. One confused, one mistaken—both mirrors of Tuxilles' past.
- Added symbolic glow to Jamie’s cracked screen, echoing the scars that came before.
- Staged  inside the scroll, tying the reader’s path to the narrative’s.
- Extended the Trickster’s influence with a final whisper and planted the seed of Marcus’ future mistake.

The red hat was not worn—it was laid down. Because some roles are heavier than symbols. And because the next teacher is already rising.