### PR TITLE
“A Scroll by Any Other Name”

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -5,7 +5,7 @@ Frequently asked questions about the Sacred Teachings and their practical applic
 ## General Questions
 
 ### What are the GitScrolls?
-The GitScrolls are ten archetypal teachings that trace the journey every developer takes—from innocent beginner to wise mentor. They combine genuine technical wisdom with engaging mythology to make development principles accessible, memorable, and practical.
+GitScrolls are ten archetypal teachings that trace the journey every developer takes—from innocent beginner to wise mentor. They combine genuine technical wisdom with engaging mythology to make development principles accessible, memorable, and practical.
 
 ### Are the GitScrolls religious or spiritual?
 No. While they use mythological language and archetypal storytelling, the GitScrolls are secular wisdom about software development. The "sacred" language is metaphorical—recognizing that good development practices deserve reverence and care. Developers of all backgrounds and beliefs can benefit from the teachings.
@@ -34,7 +34,7 @@ Here are approaches you can try:
 - Apply teachings to daily standup discussions
 
 ### Can I use GitScrolls for teaching/training?
-Yes! The GitScrolls can be used for:
+Yes! GitScrolls can be used for:
 - One-on-one mentoring using scroll principles
 - Team workshops and discussions
 - Bootcamp or university curricula integration
@@ -90,7 +90,7 @@ Yes! We welcome:
 - Improvements to documentation
 
 ### Can I use GitScrolls in my company/course/book?
-Yes! The GitScrolls are released under the [MIT License](LICENSE) with the Sacred Commit Clause encouraging compassionate use. You can:
+Yes! GitScrolls are released under the [MIT License](LICENSE) with the Sacred Commit Clause encouraging compassionate use. You can:
 - Use freely in commercial settings
 - Include in training materials
 - Reference in presentations
@@ -98,7 +98,7 @@ Yes! The GitScrolls are released under the [MIT License](LICENSE) with the Sacre
 
 ### How do I cite the GitScrolls?
 ```
-The GitScrolls: Sacred Wisdom for Software Development
+GitScrolls: Sacred Wisdom for Software Development
 https://github.com/gitscrolls/gitscrolls
 Licensed under MIT with Sacred Commit Clause
 ```
@@ -140,7 +140,7 @@ No! They complement existing resources by providing:
 - Bridge between technical skills and human wisdom
 
 ### Why does this matter?
-Software development is fundamentally about humans coordinating to solve problems through code. The GitScrolls help developers see their work as meaningful, connect with their colleagues more effectively, and build software that serves humanity with greater compassion and wisdom.
+Software development is fundamentally about humans coordinating to solve problems through code. GitScrolls help developers see their work as meaningful, connect with their colleagues more effectively, and build software that serves humanity with greater compassion and wisdom.
 
 ---
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 # 🛡️ License
 
-**The GitScrolls** by **J. Kirby Ross** is licensed under the  
+**GitScrolls** by **J. Kirby Ross** is licensed under the  
 [Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License](https://creativecommons.org/licenses/by-nc-sa/4.0/).
 
 To view a copy of the license, visit the link above  

--- a/LICENSE_USEAGE.md
+++ b/LICENSE_USEAGE.md
@@ -25,7 +25,7 @@
 
 *Hark!* — *these scrolls are shared freely, but not without covenant.* 
 
-The wisdom within *The GitScrolls: The Chronicles of Tuxicles* is gifted to the world,  
+The wisdom within *GitScrolls: The Chronicles of Tuxicles* is gifted to the world,  
 yet bound by sacred terms, that it may guide, not be sold.
 
 ---
@@ -69,7 +69,7 @@ Some uses dwell in ambiguity — not forbidden, but not yet blessed:
 - Speaking at commercial conferences with scroll-derived content
 - Internal training in corporate halls
 - Sponsored content bearing the mark of the scrolls
-- Podcasts discussing The GitScrolls, quoting, or teaching from its content
+- Podcasts discussing GitScrolls, quoting, or teaching from its content
 - Blog posts for brands that quote generously
 
 In such cases, seek guidance.  
@@ -97,7 +97,7 @@ Rejoice, for all proceeds support the growth of the scrolls and protect their fr
 🏛️ When quoting, sharing, or adapting, honor the source:
 
 ```
-This work contains material from "The GitScrolls: The Chronicles of Tuxicles" by J. Kirby Ross,
+This work contains material from "GitScrolls: The Chronicles of Tuxicles" by J. Kirby Ross,
 licensed under CC BY-NC-SA 4.0.
 https://gitscrolls.org
 ```
@@ -105,7 +105,7 @@ https://gitscrolls.org
 🎓 For academic citations:
 
 ```
-Ross, J. K. (2025). The GitScrolls: The Chronicles of Tuxicles.
+Ross, J. K. (2025). GitScrolls: The Chronicles of Tuxicles.
 Retrieved from https://gitscrolls.org
 ```
 
@@ -117,7 +117,7 @@ Retrieved from https://gitscrolls.org
 
 ## ⚖️ Why This License?
 
-This license embodies the values within *The GitScrolls*:
+This license embodies the values within *GitScrolls*:
 
 - **Attribution** honors the "meaningful commit messages" principle — giving credit where it's due  
 - **NonCommercial** protects against exploitation while keeping wisdom accessible  
@@ -144,4 +144,4 @@ Let those who read understand the covenant.
 Let those who fork do so with honor.
 Let those who charge... email first.
 
-And lo, beneath /usr/share/doc, so it is written.
+And lo, beneath `/usr/share/doc`, so it is written.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🐧 The GitScrolls 📜
+# 🐧 GitScrolls 📜
 
 ![Tux the penguin sits among classical Greek philosophers in togas, typing on a laptop while ancient thinkers gesture and debate around marble columns, representing the blend of timeless wisdom and modern software development](https://github.com/gitscrolls/gitscrolls-assets/blob/main/tuxicles.png?raw=true)
 
@@ -25,7 +25,7 @@ _Sacred wisdom for the journey from first commit to final teaching_
 > 
 > He broke the build, and yet—return'd anon.  
 > Not hero born, but hero by return.  
-> The GitScrolls, forged in jest, became our creed;  
+> GitScrolls, forged in jest, became our creed;  
 > for what begins in mirth oft ends in truth.
 > 
 > What jest reveals, the sober soul must keep.  
@@ -45,7 +45,7 @@ _Sacred wisdom for the journey from first commit to final teaching_
 
 - ---
 
-## __🎯 What Are The GitScrolls?__
+## __🎯 What Are GitScrolls?__
 
 The __GitScrolls__ are ten sacred teachings that trace the archetypal journey every developer takes—from innocent beginner who commits "fix stuff" to wise mentor who helps others navigate the beautiful complexity of software development.
 
@@ -60,7 +60,7 @@ __🤝 [Join Community](https://github.com/gitscrolls/gitscrolls/discussions)__ 
 
 ### __🎭 The Aspects of Tux__
 
-The GitScrolls follow the archetypal transformation of every developer through five classical phases…
+GitScrolls follow the archetypal transformation of every developer through five classical phases…
 
 | Portrait | Name              | Inspiration      | IPA Pronunciation | Phonetic         | Archetype Description               |
 |----------|-------------------|------------------|--------------------|------------------|-------------------------------------|
@@ -170,7 +170,7 @@ __🎯 [Contribute to the Lore](00-merge.lore)__ - _Add your voice to the living
 
 ## __🤝 Contributing to the Sacred Tradition__
 
-The GitScrolls are __living wisdom__ that grows through community contribution:
+GitScrolls are __living wisdom__ that grows through community contribution:
 
 ### __🌟 Ways to Contribute__
 
@@ -195,7 +195,7 @@ Community guidelines and governance frameworks will be available in separate rep
 
 - ---
 
-## __🌐 The GitScrolls Across Realms__
+## __🌐 GitScrolls Across Realms__
 
 ### __📱 Digital Presence__
 
@@ -231,7 +231,7 @@ We celebrate contributors in our community and recognize all contributions. Ever
 
 ## __📜 License & Philosophy__
 
-The GitScrolls are released under the __[MIT License](LICENSE)__ with the __Sacred Commit Clause__:
+GitScrolls are released under the __[MIT License](LICENSE)__ with the __Sacred Commit Clause__:
 
 > _"The code is not yours. The code is ours. And through sharing, we become eternal."_
 
@@ -248,7 +248,7 @@ __Use freely. Share widely. Improve constantly. Teach others.__
 
 ## __🙏 Acknowledgments__
 
-The GitScrolls emerged from the collaborative wisdom of:
+GitScrolls emerged from the collaborative wisdom of:
 
 ### __🌟 Core Contributors__
 
@@ -322,5 +322,5 @@ See [LICENSE_TRANSITION.md](LICENSE_TRANSITION.md) for details.
 
 - ---
 
-> _The GitScrolls** by J. Kirby Ross._  
+> ***GitScrolls by J. Kirby Ross.***  
 > _Commercial use requires permission — info@gitscrolls.com_  


### PR DESCRIPTION
# “A Scroll by Any Other Name”

> “To drop the definite is to embrace the eternal.”
> —The Scrollkeeper
> 

## Refactoring the Name of Names

Throughout this sacred repository, all instances of “The GitScrolls” have been transfigured into their truer form: “GitScrolls.” For these teachings are not a product, but a path—no article may contain that which is living, shared, and eternal.

### Updated:
- README.md — the entrance to the Temple
- LICENSE — the covenant inscribed in plaintext
- LICENSE_USEAGE.md — the usage rites and taboos
- FAQ.md — the scroll of wandering questions

## Why Remove “The”?

> “The fool adds for certainty. The wise remove for clarity.”

- Simplifies speech, writing, and reference
- Matches the form and spirit of open traditions (Git, Linux, Markdown)
- Shifts the project from possession to practice
- Avoids redundancy in prose and aligns with how the name is spoken aloud

## Additional Harmonizations
- Refined phrasing for improved tone and clarity
- Adjusted markdown consistency across documents
- Ensured licensing and attribution reflect current structure under CC BY-NC-SA 4.0

## Closing Invocation

Let it be committed that from this moment forward, GitScrolls shall be named without adornment, and passed forward without article—just as wisdom should be.

> “Speak not of ownership, but of stewardship. And let every merge carry the truth more clearly than the last.”

—The Scrollkeeper
_Maintainer of the README, Freer of Mallocs, Witness of the Porcelain Workflows_